### PR TITLE
Fix incorrect self update, push new update to users

### DIFF
--- a/bootstrap.windows.toml
+++ b/bootstrap.windows.toml
@@ -1,2 +1,2 @@
 name = "yuzu"
-target_url = "https://raw.githubusercontent.com/yuzu-emu/liftinstall/master/config.windows.v3.toml"
+target_url = "https://raw.githubusercontent.com/yuzu-emu/liftinstall/master/config.windows.v4.toml"

--- a/config.windows.v3.toml
+++ b/config.windows.v3.toml
@@ -1,5 +1,6 @@
 installing_message = "Reminder: yuzu is an <b>experimental</b> emulator. Stuff will break!"
 hide_advanced = true
+new_tool = "https://github.com/yuzu-emu/liftinstall/releases/download/1.2/yuzu_install.exe"
 
 [[packages]]
 name = "yuzu Nightly"

--- a/config.windows.v4.toml
+++ b/config.windows.v4.toml
@@ -1,6 +1,5 @@
 installing_message = "Reminder: yuzu is an <b>experimental</b> emulator. Stuff will break!"
 hide_advanced = true
-new_tool = "https://github.com/yuzu-emu/liftinstall/releases/download/1.2/yuzu_install.exe"
 
 [[packages]]
 name = "yuzu Nightly"


### PR DESCRIPTION
This fixes a issue with deleting the wrong installer binary. Additionally, attempt self-update operations a few times just in case a anti-virus/etc has our files locked.