### PR TITLE
Move to tar.xz as the main distribution format

### DIFF
--- a/config.windows.v8.toml
+++ b/config.windows.v8.toml
@@ -7,7 +7,7 @@ description = "Includes frequent updates to yuzu with all the latest reviewed an
 default = true
     [packages.source]
     name = "github"
-    match = "^yuzu-windows-msvc-[0-9]*-[0-9a-f]*.zip$"
+    match = "^yuzu-windows-msvc-[0-9]*-[0-9a-f]*.tar.xz$"
         [packages.source.config]
         repo = "yuzu-emu/yuzu-mainline"
     [[packages.shortcuts]]


### PR DESCRIPTION
Really big PR.

Tested and verified working. Can be reverted with no effects if causes issues.