### PR TITLE
Change the default shortcut location to comply with Azure changes

### DIFF
--- a/config.windows.v8.toml
+++ b/config.windows.v8.toml
@@ -12,5 +12,5 @@ default = true
         repo = "yuzu-emu/yuzu-mainline"
     [[packages.shortcuts]]
     name = "yuzu"
-    relative_path = "yuzu-windows-msvc/yuzu.exe"
+    relative_path = "yuzu-windows-msvc-mainline/yuzu.exe"
     description = "Launch yuzu"


### PR DESCRIPTION
The default folder name changed from `yuzu-windows-msvc` to `yuzu-windows-msvc-mainline`.