### PR TITLE
Revert "Change the default shortcut location to comply with Azure changes"

### DIFF
--- a/config.windows.v8.toml
+++ b/config.windows.v8.toml
@@ -12,5 +12,5 @@ default = true
         repo = "yuzu-emu/yuzu-mainline"
     [[packages.shortcuts]]
     name = "yuzu"
-    relative_path = "yuzu-windows-msvc-mainline/yuzu.exe"
+    relative_path = "yuzu-windows-msvc/yuzu.exe"
     description = "Launch yuzu"


### PR DESCRIPTION
Reverts yuzu-emu/liftinstall#15

We intended first to version bump if this fails, but I'm unable to build a new version of lift at this time, so reverting is our current plan until we have more time to test this.