### PR TITLE
ui/AuthenticationView: trim out whitespaces

### DIFF
--- a/ui/src/views/AuthenticationView.vue
+++ b/ui/src/views/AuthenticationView.vue
@@ -119,7 +119,7 @@ export default {
       // setter
       set: function (newValue) {
         try {
-          var split = atob(newValue).split(':')
+          var split = atob(newValue.trim()).split(':')
           this.$root.$data.username = split[0];
           this.$root.$data.token = split[1];
           this.invalid_token = false;


### PR DESCRIPTION
This is a simple PR with only one change:

- Trim out the whitespaces before `base64` decoding the token.