### PR TITLE
general: Fix Linux build

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 cd /liftinstall || exit 1
 
-# setup NodeJS
-curl -sL https://deb.nodesource.com/setup_12.x | bash -
-# setup Yarn
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-
-apt-get update
-apt-get install -y libwebkit2gtk-4.0-dev libssl-dev nodejs yarn
-
 yarn --cwd ui
 
-cargo build
+cargo build --release

--- a/.travis/exec.sh
+++ b/.travis/exec.sh
@@ -1,6 +1,4 @@
 #!/bin/bash -ex
 
 # the UID for the container yuzu user is 1027
-sudo chown -R 1027 ./
-docker run -v $(pwd):/liftinstall -t yuzuemu/build-environments:linux-liftinstall /bin/bash /liftinstall/.travis/build.sh
-sudo chown -R $(id -u):$(id -g) ./
+docker run -u root -v $(pwd):/liftinstall -t yuzuemu/build-environments:linux-liftinstall /bin/bash /liftinstall/.travis/build.sh

--- a/.travis/exec.sh
+++ b/.travis/exec.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+
+# the UID for the container yuzu user is 1027
+sudo chown -R 1027 ./
+docker run -v $(pwd):/liftinstall -t yuzuemu/build-environments:linux-liftinstall /bin/bash /liftinstall/.travis/build.sh
+sudo chown -R $(id -u):$(id -g) ./

--- a/bootstrap.linux.toml
+++ b/bootstrap.linux.toml
@@ -1,2 +1,2 @@
 name = "yuzu"
-target_url = "https://raw.githubusercontent.com/yuzu-emu/liftinstall/master/config.linux.v2.toml"
+target_url = "https://raw.githubusercontent.com/yuzu-emu/liftinstall/master/config.linux.v3.toml"

--- a/config.linux.v3.toml
+++ b/config.linux.v3.toml
@@ -1,0 +1,58 @@
+installing_message = "Reminder: yuzu is an <b>experimental</b> emulator. Stuff will break!"
+hide_advanced = true
+
+[authentication]
+# Base64 encoded version of the public key for validating the JWT token. Must be in DER format
+pub_key_base64 = "MIIBCgKCAQEAs5K6s49JVV9LBMzDrkORsoPSYsv1sCXDtxjp4pn8p0uPSvJAsbNNmdIgCjfSULzbHLM28MblnI4zYP8ZgKtkjdg+Ic5WQbS5iBAkf18zMafpOrotTArLsgZSmUfNYt0SOiN17D+sq/Ov/CKXRM9CttKkEbanBTVqkx7sxsHVbkI6tDvkboSaNeVPHzHlfAbvGrUo5cbAFCB/KnRsoxr+g7jLKTxU1w4xb/pIs91h80AXV/yZPXL6ItPM3/0noIRXjmoeYWf2sFQaFALNB2Kef0p6/hoHYUQP04ZSIL3Q+v13z5X2YJIlI4eLg+iD25QYm9V8oP3+Xro4vd47a0/maQIDAQAB"
+# URL to authenticate against. This must return a JWT token with their permissions and a custom claim patreonInfo with the following structure
+# "patreonInfo": { "linked": false, "activeSubscription": false }
+# If successful, the frontend will use this JWT token as a Bearer Authentication when requesting the binaries to download
+auth_url = "https://api.yuzu-emu.org/jwt/installer/"
+    [authentication.validation]
+    iss = "citra-core"
+    aud = "installer"
+
+[[packages]]
+name = "yuzu Early Access"
+description = "Preview release with the newest features for the supporters."
+icon = "thicc_logo_installer__ea_shadow.png"
+requires_authorization = true
+# puts a "new" ribbon the package select
+is_new = true
+    [packages.extended_description]
+    no_action_description = "Thank you for your support!"
+    # Displayed when the package has no authentication for the user
+    need_authentication_description = "Click here to sign in with your yuzu account for Early Access"
+    # Displayed when the package has an authentication, but the user has not linked their account
+    need_link_description = "You are signed in, but you need to link your Patreon account! Click here for more details"
+    # Displayed when the package has an authentication, but the user has not linked their account
+    need_subscription_description = "You are signed in, but you need to link your Patreon account! Click here for more details"
+    # Displayed when the package has an authentication, but the user has not linked their account
+    need_reward_tier_description = "You are signed in, but are not backing an eligible reward tier! Click here for more details"
+
+    [packages.source]
+    name = "patreon"
+    match = "^yuzu-linux-[0-9]*-[0-9a-f]*.tar.xz$"
+        [packages.source.config]
+        repo = "earlyaccess"
+    [[packages.shortcuts]]
+    name = "yuzu Early Access"
+    relative_path = "yuzu-linux-early-access/yuzu-early-access.AppImage"
+    description = "Launch yuzu Early Access"
+
+
+[[packages]]
+name = "yuzu"
+description = "Includes frequent updates to yuzu with all the latest reviewed and tested features."
+icon = "thicc_logo_installer_shadow.png"
+default = true
+    [packages.source]
+    name = "github"
+    match = "^yuzu-linux-[0-9]*-[0-9a-f]*.tar.xz$"
+        [packages.source.config]
+        repo = "yuzu-emu/yuzu-mainline"
+    [[packages.shortcuts]]
+    name = "yuzu"
+    relative_path = "yuzu-linux-mainline/yuzu"
+    description = "Launch yuzu"
+

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -97,6 +97,7 @@ pub struct InstallerFramework {
     // If we just completed an uninstall, and we should clean up after ourselves.
     pub burn_after_exit: bool,
     pub launcher_path: Option<String>,
+    pub is_windows: bool,
 }
 
 /// Contains basic properties on the status of the session. Subset of InstallationFramework.
@@ -453,6 +454,10 @@ impl InstallerFramework {
             is_launcher: false,
             burn_after_exit: false,
             launcher_path: None,
+            #[cfg(windows)]
+            is_windows: true,
+            #[cfg(not(windows))]
+            is_windows: false,
         }
     }
 
@@ -480,6 +485,10 @@ impl InstallerFramework {
             is_launcher: false,
             burn_after_exit: false,
             launcher_path: None,
+            #[cfg(windows)]
+            is_windows: true,
+            #[cfg(not(windows))]
+            is_windows: false,
         })
     }
 }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -454,10 +454,7 @@ impl InstallerFramework {
             is_launcher: false,
             burn_after_exit: false,
             launcher_path: None,
-            #[cfg(windows)]
-            is_windows: true,
-            #[cfg(not(windows))]
-            is_windows: false,
+            is_windows: cfg!(windows),
         }
     }
 
@@ -485,10 +482,7 @@ impl InstallerFramework {
             is_launcher: false,
             burn_after_exit: false,
             launcher_path: None,
-            #[cfg(windows)]
-            is_windows: true,
-            #[cfg(not(windows))]
-            is_windows: false,
+            is_windows: cfg!(windows),
         })
     }
 }

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -312,7 +312,7 @@ mod natives {
         name: &str,
         description: &str,
         target: &str,
-        args: &[&str],
+        args: &str,
         working_dir: &str,
         exe_path: &str,
     ) -> Result<String, String> {

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -333,8 +333,8 @@ mod natives {
                 };
                 path.push(format!("{}.desktop", slugify(name))); // file name
                 let desktop_file = format!(
-                    "[Desktop Entry]\nName={}\nExec=\"{}\" {}\nComment={}\nPath={}\n",
-                    name, target, args, description, working_dir
+                "[Desktop Entry]\nType=Application\nName={}\nExec=\"{}\" {}\nComment={}\nPath={}\nIcon=yuzu\n",
+                name, target, args, description, working_dir
                 );
                 let desktop_f = File::create(path);
                 let mut desktop_f = match desktop_f {

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -314,6 +314,7 @@ mod natives {
         target: &str,
         args: &str,
         working_dir: &str,
+        exe_path: &str,
     ) -> Result<String, String> {
         // FIXME: no icon will be shown since no icon is provided
         let data_local_dir = dirs::data_local_dir();

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -331,7 +331,7 @@ mod natives {
                         ));
                     }
                 };
-                path.push(format!("{}.desktop", slugify(name))); // file name
+                path.push(format!("yuzu-maintenance-tool_{}.desktop", slugify(name))); // file name
                 let desktop_file = format!(
                 "[Desktop Entry]\nType=Application\nName={}\nExec=\"{}\" {}\nComment={}\nPath={}\nIcon=yuzu\n",
                 name, target, args, description, working_dir

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -312,7 +312,7 @@ mod natives {
         name: &str,
         description: &str,
         target: &str,
-        args: &str,
+        args: &[&str],
         working_dir: &str,
         exe_path: &str,
     ) -> Result<String, String> {

--- a/src/tasks/install_desktop_shortcut.rs
+++ b/src/tasks/install_desktop_shortcut.rs
@@ -13,6 +13,8 @@ use logging::LoggingErrors;
 
 #[cfg(windows)]
 use native::create_desktop_shortcut;
+#[cfg(target_os = "linux")]
+use native::create_shortcut;
 
 pub struct InstallDesktopShortcutTask {
     pub name: String,
@@ -71,7 +73,6 @@ impl Task for InstallDesktopShortcutTask {
             "maintenancetool"
         };
 
-        #[cfg(windows)]
         for shortcut in package.shortcuts {
             let tool_path = path.join(platform_extension);
             let tool_path = tool_path
@@ -83,7 +84,19 @@ impl Task for InstallDesktopShortcutTask {
                 .to_str()
                 .log_expect("Unable to build shortcut metadata (exe)");
 
+            #[cfg(windows)]
             installed_files.push(create_desktop_shortcut(
+                &shortcut.name,
+                &shortcut.description,
+                tool_path,
+                // TODO: Send by list
+                &format!("--launcher \"{}\"", exe_path),
+                &starting_dir,
+                exe_path,
+            )?);
+
+            #[cfg(target_os = "linux")]
+            installed_files.push(create_shortcut(
                 &shortcut.name,
                 &shortcut.description,
                 tool_path,

--- a/src/tasks/install_desktop_shortcut.rs
+++ b/src/tasks/install_desktop_shortcut.rs
@@ -100,8 +100,7 @@ impl Task for InstallDesktopShortcutTask {
                 &shortcut.name,
                 &shortcut.description,
                 tool_path,
-                // TODO: Send by list
-                &format!("--launcher \"{}\"", exe_path),
+                &["--launcher", exe_path],
                 &starting_dir,
                 exe_path,
             )?);

--- a/src/tasks/install_desktop_shortcut.rs
+++ b/src/tasks/install_desktop_shortcut.rs
@@ -11,6 +11,7 @@ use config::PackageDescription;
 
 use logging::LoggingErrors;
 
+#[cfg(windows)]
 use native::create_desktop_shortcut;
 
 pub struct InstallDesktopShortcutTask {
@@ -70,6 +71,7 @@ impl Task for InstallDesktopShortcutTask {
             "maintenancetool"
         };
 
+        #[cfg(windows)]
         for shortcut in package.shortcuts {
             let tool_path = path.join(platform_extension);
             let tool_path = tool_path

--- a/src/tasks/install_desktop_shortcut.rs
+++ b/src/tasks/install_desktop_shortcut.rs
@@ -100,7 +100,7 @@ impl Task for InstallDesktopShortcutTask {
                 &shortcut.name,
                 &shortcut.description,
                 tool_path,
-                &["--launcher", exe_path],
+                &format!("--launcher \"{}\"", exe_path),
                 &starting_dir,
                 exe_path,
             )?);

--- a/ui/src/views/AuthenticationView.vue
+++ b/ui/src/views/AuthenticationView.vue
@@ -65,7 +65,7 @@
       </p>
     </div>
 
-    <div class="is-right-floating is-bottom-floating">
+    <div class="is-right-floating is-bottom-floating" v-scroll>
       <p class="control">
         <a class="button is-dark is-medium" v-on:click="verify_token">Verify Token</a>
       </p>
@@ -166,6 +166,13 @@ export default {
     error: function() {
       this.verification_opened = true;
     }
+  },
+  directives: {
+      scroll: {
+          inserted: function (el) {
+              el.scrollIntoView()
+          }
+      }
   }
 }
 </script>

--- a/ui/src/views/CompleteView.vue
+++ b/ui/src/views/CompleteView.vue
@@ -3,7 +3,7 @@
         <div v-if="was_migrate">
           <h4 class="subtitle">You have been moved to the new, single version of {{ $root.$data.attrs.name }}.</h4>
 
-          <p>You can find your installed applications in your start menu - if you were in the middle of something, just reattempt.</p>
+          <p>You can find your installed applications in your applications menu - if you were in the middle of something, just reattempt.</p>
 
           <img src="../assets/how-to-open.png" alt="Where yuzu is installed"/>
         </div>
@@ -11,20 +11,20 @@
             <div v-if="has_installed">
                 <h4 class="subtitle">{{ $root.$data.attrs.name }} has been updated.</h4>
 
-                <p>You can find your installed applications in your start menu.</p>
+                <p>You can find your installed applications in your applications menu.</p>
             </div>
             <div v-else>
                 <h4 class="subtitle">{{ $root.$data.attrs.name }} is already up to date!</h4>
 
-                <p>You can find your installed applications in your start menu.</p>
+                <p>You can find your installed applications in your applications menu.</p>
             </div>
         </div>
         <div v-else-if="was_install">
             <h4 class="subtitle">Thanks for installing {{ $root.$data.attrs.name }}!</h4>
 
-            <p>You can find your installed applications in your start menu.</p>
+            <p>You can find your installed applications in your applications menu.</p>
             <br>
-            <img src="../assets/how-to-open.png" alt="Where yuzu is installed"/>
+            <img src="../assets/how-to-open.png" alt="Where yuzu is installed" v-if="$root.$data.metadata.is_windows"/>
         </div>
         <div v-else>
             <h4 class="subtitle">{{ $root.$data.attrs.name }} has been uninstalled.</h4>

--- a/ui/src/views/SelectPackages.vue
+++ b/ui/src/views/SelectPackages.vue
@@ -12,7 +12,7 @@
             <span v-if="Lpackage.installed"><i>(installed)</i></span>
           </label>
           <div>
-            <img class="package-icon" :src="`${publicPath + Lpackage.icon}`" v-if="$root.$data.metadata.is_windows"/>
+            <img class="package-icon" :src="`${publicPath + Lpackage.icon}`"/>
             <p style="padding-top: 4px;" class="package-description">
               {{ Lpackage.description }}
             </p>

--- a/ui/src/views/SelectPackages.vue
+++ b/ui/src/views/SelectPackages.vue
@@ -23,8 +23,11 @@
         </div>
         <div class="tile is-child is-6 box clickable-box" v-if="!$root.$data.metadata.preexisting_install"  v-on:click.capture.stop="installDesktopShortcut = !installDesktopShortcut">
           <h4>Install Options</h4>
-          <b-checkbox v-model="installDesktopShortcut">
+          <b-checkbox v-model="installDesktopShortcut" v-if="$root.$data.metadata.is_windows">
             Create Desktop Shortcut
+          </b-checkbox>
+          <b-checkbox v-model="installDesktopShortcut" v-if="!$root.$data.metadata.is_windows">
+            Create Shortcut
           </b-checkbox>
         </div>
       </div>

--- a/ui/src/views/SelectPackages.vue
+++ b/ui/src/views/SelectPackages.vue
@@ -12,7 +12,7 @@
             <span v-if="Lpackage.installed"><i>(installed)</i></span>
           </label>
           <div>
-            <img class="package-icon" :src="`${publicPath + Lpackage.icon}`"/>
+            <img class="package-icon" :src="`${publicPath + Lpackage.icon}`" v-if="$root.$data.metadata.is_windows"/>
             <p style="padding-top: 4px;" class="package-description">
               {{ Lpackage.description }}
             </p>


### PR DESCRIPTION
Requires yuzu-emu/yuzu#6667
Soft-requires yuzu-emu/build-environments#34

Fixes the couple of compilation errors that master has on Linux with shortcuts. Fixes the outputted shortcuts which were not compliant with https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html . Creates and targets config.linux.v3.toml which is based on config.windows.v10.toml. 

Couple things to note. A workaround was used to display the `Verify Token` button, which was otherwise hidden by the small window size -- margins will not be correct but at least it will be functional. The `yuzu` icon specified in the .desktop files are not common among Linux distros, but those who have the icon will work.