### PR TITLE
linux v3: Use AppImage for Mainline

### DIFF
--- a/config.linux.v3.toml
+++ b/config.linux.v3.toml
@@ -53,6 +53,6 @@ default = true
         repo = "yuzu-emu/yuzu-mainline"
     [[packages.shortcuts]]
     name = "yuzu"
-    relative_path = "yuzu-linux-mainline/yuzu"
+    relative_path = "yuzu-linux-mainline/yuzu-mainline.AppImage"
     description = "Launch yuzu"
 


### PR DESCRIPTION
The regular yuzu executable is not anywhere near as guaranteed to run as the AppImage is.